### PR TITLE
Invalid class usage

### DIFF
--- a/src/Pagination.php
+++ b/src/Pagination.php
@@ -62,7 +62,7 @@ class Pagination extends \yii\data\Pagination
         $pageSize = (int) $pageSize;
         if (($params = $this->params) === null) {
             $request = Yii::$app->getRequest();
-            $params = $request instanceof Request ? $request->getQueryParams() : [];
+            $params = $request instanceof \yii\web\Request ? $request->getQueryParams() : [];
         }
 
         if ($lastKey !== null || $this->forcePageParam) {


### PR DESCRIPTION
The `Request` class not imported, and because it's only used as 'instanceof' parameter, it doesn't throw error. This mistake make LinkPager doesn't works correctly when the page have other query parameter.
