### PR TITLE
Compatibility with PHP >7

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -7,7 +7,7 @@
 
 namespace UrbanIndo\Yii2\DynamoDb;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\ArrayHelper;
 use yii\base\InvalidParamException;
 use InvalidArgumentException;
@@ -19,7 +19,7 @@ use Exception;
  *
  * @author Petra Barus <petra.barus@gmail.com>
  */
-class QueryBuilder extends Object
+class QueryBuilder extends BaseObject
 {
     /**
      * The prefix for automatically generated query binding parameters.


### PR DESCRIPTION
Fixes "Cannot use yii\base\Object as Object because 'Object' is a special class name"