### PR TITLE
BaseObject

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -8,12 +8,12 @@ namespace UrbanIndo\Yii2\DynamoDb;
 
 use Aws\DynamoDb\DynamoDbClient;
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * @author Petra Barus <petra.barus@gmail.com>
  */
-class Command extends Object
+class Command extends BaseObject
 {
 
     /**


### PR DESCRIPTION
Fixes "Cannot use yii\base\Object as Object because 'Object' is a special class name"